### PR TITLE
Bug: Fix incorrect get_success_flag indexing

### DIFF
--- a/atommover/algorithms/Algorithm_class.py
+++ b/atommover/algorithms/Algorithm_class.py
@@ -7,6 +7,7 @@
 
 import numpy as np
 
+
 class Algorithm:
     """ 
     Parent class for all algorithms. 
@@ -98,10 +99,10 @@ class Algorithm:
             state = state.reshape(np.shape(target))
 
         if n_species == 1:
-            if np.array_equal(state[start_row:end_row, start_col:end_col],target[start_row:end_row, start_col:end_col]):
+            if np.array_equal(state[start_row:end_row + 1, start_col:end_col + 1],target[start_row:end_row + 1, start_col:end_col + 1]):
                 success_flag = True
         elif n_species == 2:
-            if np.array_equal(state[start_row:end_row, start_col:end_col,:],target[start_row:end_row, start_col:end_col,:]):
+            if np.array_equal(state[start_row:end_row + 1, start_col:end_col + 1,:],target[start_row:end_row + 1, start_col:end_col + 1,:]):
                 success_flag = True
         
         return success_flag


### PR DESCRIPTION
Algorithm.get_success_flag() returns True when it is not supposed to due to incorrect slicing of matrix and target arrays.

The upper bound when slicing an numpy array is exclusive so you need to add 1 to the end_col and end_row variables to slice the proper array size and capture the full target array.