### PR TITLE
Format and fix linting errors in AtomArray.py

### DIFF
--- a/atommover/utils/AtomArray.py
+++ b/atommover/utils/AtomArray.py
@@ -57,13 +57,13 @@ class AtomArray:
         geom: ArrayGeometry = ArrayGeometry.RECTANGULAR,
     ):
         self.geom = geom
-        self.shape = shape
         if n_species in [1, 2] and type(n_species) == int:
             self.n_species = n_species
         else:
             raise ValueError(
                 f"Invalid entry for parameter `n_species`: {n_species}. The simulator only supports single and dual species arrays. "
             )
+        self.shape = shape
         self.params = params
         self.error_model = error_model
 


### PR DESCRIPTION
A few general changes:

(1) Formatted code with black and isort for improved readability (I highly suggest that the whole codebase gets reformatted with both and that each commit goes through auto-formatting)

(2) Fix various linting issues

- dereference unused variables
- get rid of unnecessary imports
- explicitly assign self.shape in init
- explicitly typecast each method argument and method return

(3) Changed shape attribute setter to after n_species attribute setter since the __setattr__ method requires self.n_species to be set first